### PR TITLE
Modify Kestrel connection config to not timeout

### DIFF
--- a/include/wrapper.sh
+++ b/include/wrapper.sh
@@ -19,7 +19,7 @@ cat <<- EOF > /opt/kestrel/config.scala
 
 	  queuePath = "/data"
 
-	  clientTimeout = 30.seconds
+	  clientTimeout = None
 
 	  expirationTimerFrequency = 1.second
 


### PR DESCRIPTION
The previous timeout was 30 seconds, which is unrealistic for a production environment and has no tangible benefits. This updates the config so that the TCP connection to the client will never timeout.